### PR TITLE
Feat/modernize code metrics

### DIFF
--- a/docs/code-metrics-modernization.md
+++ b/docs/code-metrics-modernization.md
@@ -1,0 +1,177 @@
+# Code Metrics Tool Research
+
+## Current State: PHPLOC
+- **phploc** by Sebastian Bergmann (creator of PHPUnit)
+- Last stable release: 7.0.2 (2020)
+- Status: Unmaintained, incompatible with PHP 8.2+
+- Provides: LOC, CLOC, NCLOC, complexity, structure metrics
+
+## Problems with PHPLOC
+1. **Unmaintained**: No updates since 2020
+2. **PHP Compatibility**: Issues with PHP 8.2+ (nikic/php-parser dependency)
+3. **Limited Insight**: Just counts, no actionable recommendations
+4. **No Modern Features**: No JSON output, CI integration, or trend tracking
+
+## Modern Alternatives
+
+### 1. **PHPMetrics** (Recommended)
+- **Status**: Actively maintained
+- **URL**: https://github.com/phpmetrics/PhpMetrics
+- **Latest**: v3.x (2024)
+- **PHP Support**: PHP 8.0+
+
+**Features**:
+- All PHPLOC metrics + more
+- **Maintainability Index** (MI score)
+- **Cyclomatic Complexity** per method/class
+- **Coupling/Cohesion** metrics (afferent/efferent coupling)
+- **Halstead Complexity** metrics
+- **Beautiful HTML reports** with charts and graphs
+- **JSON/XML output** for CI
+- **Violation tracking** (complexity thresholds)
+- **Trend analysis** (compare multiple runs)
+- **Composer integration**
+
+**Metrics Provided**:
+```
+Size Metrics:
+- Lines of Code (LOC, CLOC, NCLOC, LLOC)
+- Physical lines, logical lines
+- Average method length
+
+Complexity Metrics:
+- Cyclomatic Complexity (per method, per class)
+- Maintainability Index (0-100 scale)
+- Halstead metrics (volume, difficulty, effort)
+
+OO Metrics:
+- Coupling (afferent, efferent, instability)
+- LCOM (Lack of Cohesion of Methods)
+- Depth of Inheritance Tree (DIT)
+- Number of Children (NOC)
+
+Structure Metrics:
+- Classes, interfaces, traits
+- Methods, functions
+- Namespaces
+- Dependencies
+```
+
+**Advantages over PHPLOC**:
+- Actively maintained
+- Modern PHP support
+- Actionable insights (MI score, violations)
+- Beautiful reports
+- CI-friendly
+- Trend tracking
+
+### 2. **PHP Insights**
+- **URL**: https://github.com/nunomaduro/phpinsights
+- **Status**: Maintained
+- **Focus**: Code quality score + suggestions
+
+**Features**:
+- Combined metrics + code quality
+- **Quality score** (0-100)
+- **Suggestions** for improvements
+- Integration with PHPStan, PHP CS Fixer
+- Beautiful terminal output
+
+**Note**: More focused on code quality than pure metrics
+
+### 3. **Dephpend**
+- **URL**: https://github.com/mihaeu/dephpend
+- **Focus**: Dependency metrics specifically
+- Status: Less actively maintained
+
+### 4. **cloc** (Language-agnostic)
+- **URL**: https://github.com/AlDanial/cloc
+- **Status**: Actively maintained
+- **Focus**: Pure LOC counting across languages
+- **Note**: Not PHP-specific, less detailed OO metrics
+
+## Recommendation: PHPMetrics
+
+**Why PHPMetrics?**
+1. ✅ Direct replacement for PHPLOC (all same metrics + more)
+2. ✅ Actively maintained (PHP 8.3 support)
+3. ✅ Better output (HTML reports, JSON for CI)
+4. ✅ More insights (Maintainability Index, violations)
+5. ✅ Trend tracking (compare runs)
+6. ✅ Easy migration path
+
+**Installation**:
+```bash
+composer require --dev phpmetrics/phpmetrics
+```
+
+**Basic Usage**:
+```bash
+# Simple metrics (like phploc)
+phpmetrics --report-cli=stdout src/
+
+# HTML report
+phpmetrics --report-html=build/metrics src/
+
+# JSON output for CI
+phpmetrics --report-json=build/metrics.json src/
+
+# With violations (fail on bad MI)
+phpmetrics --violations-xml=build/violations.xml src/
+```
+
+**Output Example**:
+```
+Summary
+  Total files: 42
+  Total lines: 5432
+
+Maintainability
+  Maintainability Index: 78.4 (Good)
+  Average Complexity: 3.2
+
+Violations
+  Complex methods: 2 (>10 cyclomatic complexity)
+  Large classes: 1 (>500 LOC)
+```
+
+## Migration Strategy
+
+1. **Phase 1**: Make LOC task opt-in (not in default pipeline)
+   - Move `loc` to explicit-only like `md` and `cs`
+   - Update documentation
+
+2. **Phase 2**: Add PHPMetrics task
+   - New `Qc\Task\Metrics.php`
+   - Support both CLI and HTML report modes
+   - JSON output for CI
+   - Make opt-in initially
+
+3. **Phase 3**: Test and validate
+   - Run on components codebase
+   - Verify reports
+   - Document differences
+
+4. **Phase 4**: Promote PHPMetrics to default
+   - Add `metrics` to default QC pipeline
+   - Deprecate `loc` task
+   - Update docs
+
+## Alternative: PHP Insights for Quality Score
+
+If we want a **quality score** rather than raw metrics:
+- PHP Insights provides 0-100 score
+- Combines metrics + static analysis + code style
+- More "executive dashboard" than detailed metrics
+- Could complement PHPMetrics
+
+## Conclusion
+
+**Recommended**: Deprecate PHPLOC (make opt-in), add PHPMetrics as new default.
+
+**Benefits**:
+- Modern, maintained tool
+- All PHPLOC metrics + more
+- Better visualization
+- CI-friendly
+- Actionable insights (MI score)

--- a/src/Module/Qc.php
+++ b/src/Module/Qc.php
@@ -160,7 +160,7 @@ AVAILABLE CHECKS:
                Requires: phploc command available
                Reports: lines of code, cyclomatic complexity, dependencies
                Status: Not in default pipeline (opt-in only)
-               Note: PHPLOC is unmaintained, use 'metrics' task instead
+               Note: PHPLOC is unmaintained, use metrics task instead
 
     metrics    Run PHPMetrics for modern code metrics analysis
                Requires: phpmetrics command available

--- a/src/Module/Qc.php
+++ b/src/Module/Qc.php
@@ -118,9 +118,10 @@ DEFAULT PIPELINE:
     - phpcsfixer (code style fixing)
     - unit (test suite)
     - phpstan (static analysis)
-    - loc (code metrics)
+    - metrics (code quality metrics)
 
-    Note: The "cs" (PHPCS) and "md" (PHPMD) checks must be explicitly requested.
+    Note: The "cs" (PHPCS), "md" (PHPMD), and "loc" (PHPLOC) checks must be
+    explicitly requested.
 
 AVAILABLE CHECKS:
     unit       Run the PHPUnit unit test suite
@@ -166,7 +167,7 @@ AVAILABLE CHECKS:
                Requires: phpmetrics command available
                Reports: size, complexity, maintainability index, coupling, cohesion
                Outputs: HTML report to build/metrics/, JSON to build/metrics.json
-               Status: Not in default pipeline (opt-in only)
+               Status: In default pipeline
                Note: Modern replacement for deprecated LOC task
 
     gitignore  Check .gitignore file for required entries
@@ -189,7 +190,7 @@ AUTO-FIX MODE:
     - phpcsfixer: Fixes code style issues (runs in check mode without flag)
 
 EXAMPLES:
-    # Run default pipeline (gitignore, lint, phpcsfixer, unit, phpstan)
+    # Run default pipeline (gitignore, lint, phpcsfixer, unit, phpstan, metrics)
     horde-components qc
 
     # Run only syntax check (always works, no external tools needed)

--- a/src/Module/Qc.php
+++ b/src/Module/Qc.php
@@ -156,9 +156,18 @@ AVAILABLE CHECKS:
                Supports: --fix-qc-issues to auto-fix (check mode by default)
                Outputs: JSON results to build/ directory
 
-    loc        Run PHPLOC to analyze code size and structure
+    loc        Run PHPLOC to analyze code size and structure (DEPRECATED)
                Requires: phploc command available
                Reports: lines of code, cyclomatic complexity, dependencies
+               Status: Not in default pipeline (opt-in only)
+               Note: PHPLOC is unmaintained, use 'metrics' task instead
+
+    metrics    Run PHPMetrics for modern code metrics analysis
+               Requires: phpmetrics command available
+               Reports: size, complexity, maintainability index, coupling, cohesion
+               Outputs: HTML report to build/metrics/, JSON to build/metrics.json
+               Status: Not in default pipeline (opt-in only)
+               Note: Modern replacement for deprecated LOC task
 
     gitignore  Check .gitignore file for required entries
                Requires: None (always available)
@@ -180,7 +189,7 @@ AUTO-FIX MODE:
     - phpcsfixer: Fixes code style issues (runs in check mode without flag)
 
 EXAMPLES:
-    # Run default pipeline (gitignore, lint, phpcsfixer, unit, phpstan, loc)
+    # Run default pipeline (gitignore, lint, phpcsfixer, unit, phpstan)
     horde-components qc
 
     # Run only syntax check (always works, no external tools needed)
@@ -194,13 +203,19 @@ EXAMPLES:
 
     # Run multiple specific checks
     horde-components qc unit lint
-    horde-components qc phpstan md loc
+    horde-components qc phpstan md
 
     # Explicitly run PHPMD (not in default pipeline)
     horde-components qc md
 
     # Explicitly run PHPCS (not in default pipeline)
     horde-components qc cs
+
+    # Explicitly run PHPLOC (not in default pipeline, deprecated)
+    horde-components qc loc
+
+    # Run modern metrics analysis (recommended over loc)
+    horde-components qc metrics
 
     # Check code style (will not modify files)
     horde-components qc phpcsfixer
@@ -238,8 +253,11 @@ INSTALLING REQUIRED TOOLS:
     # Install PHPCS
     composer require --dev squizlabs/php_codesniffer
 
-    # Install PHPLOC
+    # Install PHPLOC (deprecated, use phpmetrics instead)
     composer require --dev phploc/phploc
+
+    # Install PHPMetrics (modern metrics tool)
+    composer require --dev phpmetrics/phpmetrics
 
 NOTE:
     The lint check (php -l) always works without additional dependencies

--- a/src/Qc/Task/Metrics.php
+++ b/src/Qc/Task/Metrics.php
@@ -100,23 +100,19 @@ class Metrics extends Base
         }
 
         $this->getOutput()->detected("Found PHPMetrics at: {$phpmetrics}");
-        $this->getOutput()->running('Analyzing code metrics...');
 
-        // Run PHPMetrics with JSON output for parsing
+        // For now, analyze only the first (primary) source directory
+        // PHPMetrics v2.x doesn't handle multiple directories well
+        $primarySrcDir = $srcDirs[0];
+        $this->getOutput()->running("Analyzing code metrics in: " . basename($primarySrcDir) . '/');
+        $this->runPhpMetricsAnalysis($phpmetrics, $primarySrcDir, $buildDir);
+
+        // Display summary
+        $jsonOutput = $buildDir . '/metrics.json';
+        // Display summary
         $jsonOutput = $buildDir . '/metrics.json';
         $htmlOutput = $buildDir . '/metrics';
 
-        $command = sprintf(
-            '%s --report-json=%s --report-html=%s %s',
-            escapeshellarg($phpmetrics),
-            escapeshellarg($jsonOutput),
-            escapeshellarg($htmlOutput),
-            implode(' ', array_map('escapeshellarg', $srcDirs))
-        );
-
-        $this->system($command);
-
-        // Parse and display summary
         if (file_exists($jsonOutput)) {
             $this->displaySummary($jsonOutput);
         }
@@ -125,6 +121,32 @@ class Metrics extends Base
         $this->getOutput()->ok("JSON data saved: {$jsonOutput}");
 
         return 0;
+    }
+
+    /**
+     * Run PHPMetrics analysis on a directory.
+     *
+     * @param string $phpmetrics Path to phpmetrics binary.
+     * @param string $targetDir Directory to analyze.
+     * @param string $buildDir Build directory for output.
+     */
+    private function runPhpMetricsAnalysis(
+        string $phpmetrics,
+        string $targetDir,
+        string $buildDir
+    ): void {
+        $jsonOutput = $buildDir . '/metrics.json';
+        $htmlOutput = $buildDir . '/metrics';
+
+        $command = sprintf(
+            '%s --report-json=%s --report-html=%s %s',
+            escapeshellarg($phpmetrics),
+            escapeshellarg($jsonOutput),
+            escapeshellarg($htmlOutput),
+            escapeshellarg($targetDir)
+        );
+
+        $this->system($command);
     }
 
     /**

--- a/src/Qc/Task/Metrics.php
+++ b/src/Qc/Task/Metrics.php
@@ -136,20 +136,30 @@ class Metrics extends Base
     {
         $componentDir = realpath($this->_config->getPath());
 
-        // Search order: local vendor, global installation, PATH
+        // Search order: local vendor, global composer, system paths, PATH
         $possibleLocations = [
+            // 1. Local vendor (project-specific)
             $componentDir . '/vendor/bin/phpmetrics',
-            $componentDir . '/../../../vendor/bin/phpmetrics',  // Horde monorepo
+            // 2. Horde monorepo vendor
+            $componentDir . '/../../../vendor/bin/phpmetrics',
+            // 3. Global Composer (Linux/macOS)
+            getenv('HOME') . '/.composer/vendor/bin/phpmetrics',
+            getenv('HOME') . '/.config/composer/vendor/bin/phpmetrics',
+            // 4. Global Composer (Windows)
+            getenv('APPDATA') . '/Composer/vendor/bin/phpmetrics',
+            getenv('APPDATA') . '/Composer/vendor/bin/phpmetrics.bat',
+            // 5. System installations
             '/usr/local/bin/phpmetrics',
+            '/usr/bin/phpmetrics',
         ];
 
         foreach ($possibleLocations as $path) {
-            if (file_exists($path) && is_executable($path)) {
+            if ($path && file_exists($path) && is_executable($path)) {
                 return $path;
             }
         }
 
-        // Try PATH
+        // Try PATH as fallback
         $result = shell_exec('which phpmetrics 2>/dev/null');
         if ($result && trim($result)) {
             return trim($result);

--- a/src/Qc/Task/Metrics.php
+++ b/src/Qc/Task/Metrics.php
@@ -1,0 +1,252 @@
+<?php
+
+/**
+ * Copyright 2024-2026 Horde LLC (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (LGPL). If you
+ * did not receive this file, see http://www.horde.org/licenses/lgpl21.
+ *
+ * @category  Horde
+ * @copyright 2024-2026 Horde LLC
+ * @license   http://www.horde.org/licenses/lgpl21 LGPL 2.1
+ * @package   Components
+ */
+
+namespace Horde\Components\Qc\Task;
+
+/**
+ * Measure code metrics using PHPMetrics.
+ *
+ * PHPMetrics provides comprehensive code metrics including:
+ * - Size metrics (LOC, CLOC, NCLOC, LLOC)
+ * - Maintainability Index (0-100 scale)
+ * - Cyclomatic Complexity per method/class
+ * - Coupling metrics (afferent/efferent coupling)
+ * - Cohesion metrics (LCOM)
+ * - Halstead complexity metrics
+ * - Object-oriented metrics
+ *
+ * This is a modern replacement for the deprecated PHPLOC task.
+ *
+ * @author    Ralf Lang <ralf.lang@ralf-lang.de>
+ * @category  Horde
+ * @copyright 2024-2026 Horde LLC
+ * @license   http://www.horde.org/licenses/lgpl21 LGPL 2.1
+ * @package   Components
+ */
+class Metrics extends Base
+{
+    /**
+     * Get the name of this task.
+     *
+     * @return string The task name.
+     */
+    public function getName(): string
+    {
+        return 'code metrics analysis using PHPMetrics';
+    }
+
+    /**
+     * Validate the preconditions required for this task.
+     *
+     * @param array $options Additional options.
+     *
+     * @return array An empty array if all preconditions are met and a list of
+     *               error messages otherwise.
+     */
+    public function validate(array $options = []): array
+    {
+        // Check for phpmetrics binary
+        $phpmetrics = $this->findPhpMetrics();
+
+        if (!$phpmetrics) {
+            return [
+                'PHPMetrics is not available!',
+                'Install with: composer require --dev phpmetrics/phpmetrics',
+            ];
+        }
+
+        return [];
+    }
+
+    /**
+     * Run the task.
+     *
+     * @param array &$options Additional options.
+     *
+     * @return int Number of errors.
+     */
+    public function run(array &$options = []): int
+    {
+        $componentDir = realpath($this->_config->getPath());
+        $buildDir = $componentDir . DIRECTORY_SEPARATOR . 'build';
+        $phpmetrics = $this->findPhpMetrics();
+
+        if (!$phpmetrics) {
+            $this->getOutput()->error('PHPMetrics not found');
+            return 1;
+        }
+
+        // Ensure build directory exists
+        if (!is_dir($buildDir)) {
+            mkdir($buildDir, 0755, true);
+        }
+
+        // Detect source directories
+        $srcDirs = $this->detectSourceDirectories($componentDir);
+        if (empty($srcDirs)) {
+            $this->getOutput()->warn('No source directories found');
+            return 1;
+        }
+
+        $this->getOutput()->detected("Found PHPMetrics at: {$phpmetrics}");
+        $this->getOutput()->running('Analyzing code metrics...');
+
+        // Run PHPMetrics with JSON output for parsing
+        $jsonOutput = $buildDir . '/metrics.json';
+        $htmlOutput = $buildDir . '/metrics';
+
+        $command = sprintf(
+            '%s --report-json=%s --report-html=%s %s',
+            escapeshellarg($phpmetrics),
+            escapeshellarg($jsonOutput),
+            escapeshellarg($htmlOutput),
+            implode(' ', array_map('escapeshellarg', $srcDirs))
+        );
+
+        $this->system($command);
+
+        // Parse and display summary
+        if (file_exists($jsonOutput)) {
+            $this->displaySummary($jsonOutput);
+        }
+
+        $this->getOutput()->ok("HTML report generated: {$htmlOutput}/index.html");
+        $this->getOutput()->ok("JSON data saved: {$jsonOutput}");
+
+        return 0;
+    }
+
+    /**
+     * Find PHPMetrics binary.
+     *
+     * @return string|null Path to phpmetrics or null if not found.
+     */
+    private function findPhpMetrics(): ?string
+    {
+        $componentDir = realpath($this->_config->getPath());
+
+        // Search order: local vendor, global installation, PATH
+        $possibleLocations = [
+            $componentDir . '/vendor/bin/phpmetrics',
+            $componentDir . '/../../../vendor/bin/phpmetrics',  // Horde monorepo
+            '/usr/local/bin/phpmetrics',
+        ];
+
+        foreach ($possibleLocations as $path) {
+            if (file_exists($path) && is_executable($path)) {
+                return $path;
+            }
+        }
+
+        // Try PATH
+        $result = shell_exec('which phpmetrics 2>/dev/null');
+        if ($result && trim($result)) {
+            return trim($result);
+        }
+
+        return null;
+    }
+
+    /**
+     * Detect source directories to analyze.
+     *
+     * @param string $componentDir Component root directory.
+     *
+     * @return array Array of source directory paths.
+     */
+    private function detectSourceDirectories(string $componentDir): array
+    {
+        $candidates = ['src', 'lib', 'app'];
+        $dirs = [];
+
+        foreach ($candidates as $candidate) {
+            $path = $componentDir . DIRECTORY_SEPARATOR . $candidate;
+            if (is_dir($path)) {
+                $dirs[] = $path;
+            }
+        }
+
+        return $dirs;
+    }
+
+    /**
+     * Display metrics summary from JSON output.
+     *
+     * @param string $jsonFile Path to JSON metrics file.
+     */
+    private function displaySummary(string $jsonFile): void
+    {
+        $data = json_decode(file_get_contents($jsonFile), true);
+        if (!$data) {
+            return;
+        }
+
+        $this->getOutput()->plain('');
+        $this->getOutput()->bold('=== Code Metrics Summary ===');
+        $this->getOutput()->plain('');
+
+        // Extract summary metrics
+        if (isset($data['files'])) {
+            $totalFiles = count($data['files']);
+            $totalLoc = 0;
+            $totalCloc = 0;
+            $totalComplexity = 0;
+            $miScores = [];
+            $violations = 0;
+
+            foreach ($data['files'] as $file) {
+                $totalLoc += $file['loc'] ?? 0;
+                $totalCloc += $file['cloc'] ?? 0;
+                $totalComplexity += $file['ccn'] ?? 0;
+
+                if (isset($file['mi'])) {
+                    $miScores[] = $file['mi'];
+                }
+
+                // Count violations (high complexity, low MI)
+                if (($file['ccn'] ?? 0) > 10 || ($file['mi'] ?? 100) < 50) {
+                    $violations++;
+                }
+            }
+
+            $avgMi = !empty($miScores) ? array_sum($miScores) / count($miScores) : 0;
+            $ncloc = $totalLoc - $totalCloc;
+
+            printf("Files:                           %10d\n", $totalFiles);
+            printf("Lines of Code (LOC):             %10d\n", $totalLoc);
+            printf("Comment Lines (CLOC):            %10d (%.1f%%)\n", $totalCloc, $totalLoc > 0 ? ($totalCloc / $totalLoc) * 100 : 0);
+            printf("Non-Comment Lines (NCLOC):       %10d (%.1f%%)\n", $ncloc, $totalLoc > 0 ? ($ncloc / $totalLoc) * 100 : 0);
+            printf("Cyclomatic Complexity:           %10d\n", $totalComplexity);
+            printf("Average Maintainability Index:   %10.1f ", $avgMi);
+
+            // Color-code MI score
+            if ($avgMi >= 85) {
+                $this->getOutput()->green('(Excellent)');
+            } elseif ($avgMi >= 70) {
+                $this->getOutput()->ok('(Good)');
+            } elseif ($avgMi >= 50) {
+                $this->getOutput()->warn('(Fair)');
+            } else {
+                $this->getOutput()->error('(Poor)');
+            }
+
+            if ($violations > 0) {
+                $this->getOutput()->plain('');
+                $this->getOutput()->warn("Quality Issues: {$violations} file(s) with high complexity or low maintainability");
+            }
+        }
+
+        $this->getOutput()->plain('');
+    }
+}

--- a/src/Qc/Tasks.php
+++ b/src/Qc/Tasks.php
@@ -93,6 +93,9 @@ class Tasks
         foreach ($task_sequence as $task) {
             $task_errors = $task->validate($options);
             if (!empty($task_errors)) {
+                $output = $this->_dependencies->getInstance(Output::class);
+                $output->plain('');
+                $output->bold(str_repeat('-', 30));
                 $this->_dependencies->getOutput()->warn(
                     sprintf(
                         "Deactivated task \"%s\":\n\n%s",
@@ -100,6 +103,8 @@ class Tasks
                         join("\n", $task_errors)
                     )
                 );
+                $output->bold(str_repeat('-', 30));
+                $output->plain('');
             } else {
                 $selected_tasks[] = $task;
             }

--- a/src/Qc/Tasks.php
+++ b/src/Qc/Tasks.php
@@ -53,6 +53,16 @@ class Tasks
     public function __construct(private readonly Dependencies $_dependencies) {}
 
     /**
+     * Check if we are in pretend mode.
+     *
+     * @return bool True if in pretend mode.
+     */
+    public function pretend(): bool
+    {
+        return !empty($this->_options['pretend']);
+    }
+
+    /**
      * Return the named task.
      *
      * @param string $name                    The name of the task.

--- a/src/Runner/Qc.php
+++ b/src/Runner/Qc.php
@@ -83,8 +83,16 @@ class Qc
             $sequence[] = 'cs';
         }
 
-        if ($this->_doTask('loc', $arguments)) {
+        // LOC (phploc) is only run when explicitly requested, not in default pipeline
+        // Deprecated: Use 'metrics' task (PHPMetrics) instead for modern metrics
+        if ($this->_doTask('loc', $arguments, false)) {
             $sequence[] = 'loc';
+        }
+
+        // Metrics (phpmetrics) is only run when explicitly requested, not in default pipeline yet
+        // Modern replacement for deprecated LOC task
+        if ($this->_doTask('metrics', $arguments, false)) {
+            $sequence[] = 'metrics';
         }
 
         if (!empty($sequence)) {

--- a/src/Runner/Qc.php
+++ b/src/Runner/Qc.php
@@ -73,6 +73,11 @@ class Qc
             $sequence[] = 'phpstan';
         }
 
+        // Metrics (phpmetrics) provides code quality insights
+        if ($this->_doTask('metrics', $arguments)) {
+            $sequence[] = 'metrics';
+        }
+
         // PHPMD (md) is only run when explicitly requested, not in default pipeline
         if ($this->_doTask('md', $arguments, false)) {
             $sequence[] = 'md';
@@ -87,12 +92,6 @@ class Qc
         // Deprecated: Use 'metrics' task (PHPMetrics) instead for modern metrics
         if ($this->_doTask('loc', $arguments, false)) {
             $sequence[] = 'loc';
-        }
-
-        // Metrics (phpmetrics) is only run when explicitly requested, not in default pipeline yet
-        // Modern replacement for deprecated LOC task
-        if ($this->_doTask('metrics', $arguments, false)) {
-            $sequence[] = 'metrics';
         }
 
         if (!empty($sequence)) {


### PR DESCRIPTION
# Modernize code metrics

- phploc is no longer in the default qc pipeline for the qc command but still can be called by horde-components qc loc
- phpmetrics is used in the default qc pipeline and can also be called separately as horde-components qc metrics
