### PR TITLE
feat(ci): prefer repo-bundled phar over download in github bootstrap

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,8 @@
         "horde/eventdispatcher": "* || dev-FRAMEWORK_6_0",
         "horde/githubapiclient": "* || dev-FRAMEWORK_6_0",
         "horde/composer": "* || dev-FRAMEWORK_6_0",
-        "horde/phpconfigfile": "^0.0.1-alpha4 || dev-FRAMEWORK_6_0"
+        "horde/phpconfigfile": "^0.0.1-alpha4 || dev-FRAMEWORK_6_0",
+        "psr/log": "^1.1 || ^2 || ^3"
     },
     "require-dev": {
         "horde/test": "^3 || dev-FRAMEWORK_6_0",
@@ -83,5 +84,7 @@
         "branch-alias": {
             "dev-FRAMEWORK_6_0": "1.x-dev"
         }
-    }
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
 }

--- a/data/ci/bootstrap-github.sh.template
+++ b/data/ci/bootstrap-github.sh.template
@@ -83,14 +83,25 @@ fi
 PHP_VERSION=$(php -r 'echo PHP_VERSION;')
 log_info "Using runner's PHP version: $PHP_VERSION"
 
-# Stage 3: Download horde-components.phar (or use cached)
-if [ -f "$WORK_DIR/bin/horde-components.phar" ]; then
+# Stage 3: Locate horde-components.phar
+#
+# Lookup order:
+#   1. Repo-bundled phar at $GITHUB_WORKSPACE/ci-tools/horde-components.phar
+#      (committed alongside the workflow for repos that pin a specific build)
+#   2. Cached phar from a previous run at $WORK_DIR/bin/horde-components.phar
+#   3. Download from $COMPONENTS_PHAR_URL
+REPO_PHAR="$GITHUB_WORKSPACE/ci-tools/horde-components.phar"
+mkdir -p "$WORK_DIR/bin"
+COMPONENTS_PHAR="$WORK_DIR/bin/horde-components.phar"
+
+if [ -f "$REPO_PHAR" ]; then
+    log_info "Using repo-bundled horde-components.phar from ci-tools/"
+    cp "$REPO_PHAR" "$COMPONENTS_PHAR"
+    chmod +x "$COMPONENTS_PHAR"
+elif [ -f "$COMPONENTS_PHAR" ]; then
     log_info "Using cached horde-components.phar"
-    COMPONENTS_PHAR="$WORK_DIR/bin/horde-components.phar"
 else
     log_info "Downloading horde-components from $COMPONENTS_PHAR_URL"
-    mkdir -p "$WORK_DIR/bin"
-    COMPONENTS_PHAR="$WORK_DIR/bin/horde-components.phar"
 
     if ! curl -sS -L -o "$COMPONENTS_PHAR" "$COMPONENTS_PHAR_URL"; then
         log_error "Failed to download horde-components.phar"
@@ -100,11 +111,11 @@ fi
 
 # Validate it's a valid phar
 if ! php "$COMPONENTS_PHAR" help &> /dev/null; then
-    log_error "Downloaded phar is not valid or not executable"
+    log_error "horde-components.phar is not valid or not executable"
     exit 1
 fi
 
-log_info "horde-components.phar downloaded successfully"
+log_info "horde-components.phar ready at $COMPONENTS_PHAR"
 
 # Stage 4: Install sudo helper script
 log_info "Installing sudo helper script"

--- a/src/Ci/Template/TemplateRenderer.php
+++ b/src/Ci/Template/TemplateRenderer.php
@@ -38,7 +38,7 @@ class TemplateRenderer
      * This version is embedded in generated files and used to detect
      * when components are using outdated templates.
      */
-    private const TEMPLATE_VERSION = '1.0.0';
+    private const TEMPLATE_VERSION = '1.1.0';
 
     /**
      * Constructor.


### PR DESCRIPTION
Ignore a cached or downloadable horde-components.phar when a horde-components.phar is committed to ci-tools/ in the target
repository

Otherwise use the version from COMPONENTS_PHAR_URL (or cache).

Aside: Fix some dependencies
